### PR TITLE
feat: LangGraphAgentにツール呼び出し機能を追加

### DIFF
--- a/src/mnemos/adapter/langgraph_agent.py
+++ b/src/mnemos/adapter/langgraph_agent.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import StateGraph
 from langgraph.graph.state import END, START, CompiledStateGraph
+from langgraph.prebuilt import ToolNode, tools_condition
 
 from mnemos.protocols import Agent, Message
 
@@ -20,18 +21,34 @@ class MessagesState(TypedDict):
 class LangGraphAgent(Agent):
     """Langgraphを用いたエージェントの具体実装"""
 
-    def __init__(self, llm: BaseChatModel) -> None:
+    def __init__(self, llm: BaseChatModel, tools: list | None = None) -> None:
         """LanggraphAgentのコンストラクタ"""
         self.llm = llm
+        self.tools = tools
+        if self.tools is not None:
+            self.llm = llm.bind_tools(self.tools)
         self.graph = self._build_graph()
 
     def _build_graph(self) -> CompiledStateGraph:
         state_graph = StateGraph(MessagesState)  # pyrefly: ignore[bad-specialization]
-        state_graph.add_node("call_llm", self._call_llm)
 
-        state_graph.add_edge(START, "call_llm")
-        state_graph.add_edge("call_llm", END)
+        self._register_nodes(state_graph)
+        self._register_edges(state_graph)
+
         return state_graph.compile(checkpointer=MemorySaver())
+
+    def _register_nodes(self, state_graph: StateGraph) -> None:
+        state_graph.add_node("call_llm", self._call_llm)
+        if self.tools:
+            state_graph.add_node("tools", ToolNode(self.tools, handle_tool_errors=True))
+
+    def _register_edges(self, state_graph: StateGraph) -> None:
+        state_graph.add_edge(START, "call_llm")
+        if self.tools:
+            state_graph.add_conditional_edges("call_llm", tools_condition)
+            state_graph.add_edge("tools", "call_llm")
+        else:
+            state_graph.add_edge("call_llm", END)
 
     def _call_llm(self, state: MessagesState) -> dict[str, list[AIMessage]]:
         """LLMを呼び出す関数"""

--- a/src/mnemos/adapter/langgraph_agent.py
+++ b/src/mnemos/adapter/langgraph_agent.py
@@ -1,6 +1,6 @@
 """Langgraphを用いたエージェントの具体実装"""
 
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -10,6 +10,9 @@ from langgraph.graph.state import END, START, CompiledStateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
 
 from mnemos.protocols import Agent, Message
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import Runnable
 
 
 class MessagesState(TypedDict):
@@ -23,7 +26,7 @@ class LangGraphAgent(Agent):
 
     def __init__(self, llm: BaseChatModel, tools: list | None = None) -> None:
         """LanggraphAgentのコンストラクタ"""
-        self.llm = llm
+        self.llm: Runnable = llm
         self.tools = tools
         if self.tools is not None:
             self.llm = llm.bind_tools(self.tools)

--- a/tests/fake/__init__.py
+++ b/tests/fake/__init__.py
@@ -2,4 +2,4 @@ from .fake_agent import FakeAgent
 from .fake_llm import FakeLLM
 from .fake_tool import fake_error_tool, fake_tool
 
-__all__ = [FakeAgent, FakeLLM, fake_tool, fake_error_tool]
+__all__ = ["FakeAgent", "FakeLLM", "fake_error_tool", "fake_tool"]

--- a/tests/fake/__init__.py
+++ b/tests/fake/__init__.py
@@ -1,0 +1,5 @@
+from .fake_agent import FakeAgent
+from .fake_llm import FakeLLM
+from .fake_tool import fake_error_tool, fake_tool
+
+__all__ = [FakeAgent, FakeLLM, fake_tool, fake_error_tool]

--- a/tests/fake/fake_llm.py
+++ b/tests/fake/fake_llm.py
@@ -1,6 +1,18 @@
+import builtins
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from langchain_core.language_models.base import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
 
 
 class FakeLLM(FakeMessagesListChatModel):
-    def bind_tools(self, tools, **kwargs):
+    def bind_tools(
+        self,
+        tools: Sequence[builtins.dict[str, Any] | type | Callable | BaseTool],  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002, ANN401
+    ) -> Runnable[LanguageModelInput, AIMessage]:
         return self  # 何もせず自分自身を返す

--- a/tests/fake/fake_llm.py
+++ b/tests/fake/fake_llm.py
@@ -1,0 +1,6 @@
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+
+
+class FakeLLM(FakeMessagesListChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self  # 何もせず自分自身を返す

--- a/tests/fake/fake_tool.py
+++ b/tests/fake/fake_tool.py
@@ -1,0 +1,13 @@
+from langchain.tools import tool
+
+
+@tool
+def fake_tool() -> str:
+    """テスト用のツール定義。挨拶をしてくれる"""
+    return "Hello!"
+
+
+@tool
+def fake_error_tool() -> str:
+    """テスト用のツール定義。エラーを発生させる"""
+    raise Exception("This is a fake error from the tool.")  # noqa: EM101,TRY002,TRY003

--- a/tests/unit/test_conversation_service.py
+++ b/tests/unit/test_conversation_service.py
@@ -1,5 +1,5 @@
 from mnemos.core.conversation_service import ConversationService
-from tests.fake.fake_agent import FakeAgent
+from tests.fake import FakeAgent
 
 
 def test_conversation_service() -> None:

--- a/tests/unit/test_langgraph_agent.py
+++ b/tests/unit/test_langgraph_agent.py
@@ -1,7 +1,34 @@
-from langchain_core.language_models.fake_chat_models import FakeListChatModel
+import pytest
+from langchain_core.language_models.fake_chat_models import (
+    FakeListChatModel,
+)
+from langchain_core.messages import AIMessage
 
 from mnemos.adapter.langgraph_agent import LangGraphAgent
 from mnemos.protocols import Message
+from tests.fake import FakeLLM, fake_error_tool, fake_tool
+
+
+@pytest.fixture
+def setup_mock_llm():
+    def _setup(tool_name: str) -> FakeLLM:
+        return FakeLLM(
+            responses=[
+                AIMessage(
+                    content="ツールが呼び出されました!",
+                    tool_calls=[
+                        {
+                            "id": "call_1",
+                            "name": tool_name,
+                            "args": {},
+                        }
+                    ],
+                ),
+                AIMessage(content="こんにちは!"),
+            ]
+        )
+
+    return _setup
 
 
 def test_ok_response_from_langgraph_agent() -> None:
@@ -12,3 +39,32 @@ def test_ok_response_from_langgraph_agent() -> None:
         Message(content="Hello, Agent!"), thread_id="test_thread"
     )
     assert agent_response.content == expected_response
+
+
+def test_tool_called_by_langgraph_agent(setup_mock_llm) -> None:
+    expected_response = "こんにちは!"
+    llm = setup_mock_llm("fake_tool")
+    agent = LangGraphAgent(llm, tools=[fake_tool])
+    agent_response = agent.invoke(
+        Message(content="Call the tool!"), thread_id="test_thread"
+    )
+    assert agent_response.content == expected_response
+
+
+def test_tool_called_invoke_error(setup_mock_llm) -> None:
+    expected_response = "こんにちは!"
+    llm = setup_mock_llm("fake_error_tool")
+    agent = LangGraphAgent(llm, tools=[fake_error_tool])
+    agent_response = agent.invoke(
+        Message(content="Call the tool!"), thread_id="test_thread"
+    )
+    assert agent_response.content == expected_response
+
+
+def test_invalid_tool_name(setup_mock_llm) -> None:
+    llm = setup_mock_llm("non_existent_tool")
+    agent = LangGraphAgent(llm, tools=[fake_tool])
+    agent_response = agent.invoke(
+        Message(content="Call the tool!"), thread_id="test_thread"
+    )
+    assert agent_response.content == "こんにちは!"

--- a/tests/unit/test_langgraph_agent.py
+++ b/tests/unit/test_langgraph_agent.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 from langchain_core.language_models.fake_chat_models import (
     FakeListChatModel,
@@ -10,7 +12,7 @@ from tests.fake import FakeLLM, fake_error_tool, fake_tool
 
 
 @pytest.fixture
-def setup_mock_llm():
+def setup_mock_llm() -> Callable[[str], FakeLLM]:
     def _setup(tool_name: str) -> FakeLLM:
         return FakeLLM(
             responses=[
@@ -41,7 +43,7 @@ def test_ok_response_from_langgraph_agent() -> None:
     assert agent_response.content == expected_response
 
 
-def test_tool_called_by_langgraph_agent(setup_mock_llm) -> None:
+def test_tool_called_by_langgraph_agent(setup_mock_llm: Callable) -> None:
     expected_response = "こんにちは!"
     llm = setup_mock_llm("fake_tool")
     agent = LangGraphAgent(llm, tools=[fake_tool])
@@ -51,7 +53,7 @@ def test_tool_called_by_langgraph_agent(setup_mock_llm) -> None:
     assert agent_response.content == expected_response
 
 
-def test_tool_called_invoke_error(setup_mock_llm) -> None:
+def test_tool_called_invoke_error(setup_mock_llm: Callable) -> None:
     expected_response = "こんにちは!"
     llm = setup_mock_llm("fake_error_tool")
     agent = LangGraphAgent(llm, tools=[fake_error_tool])
@@ -61,7 +63,7 @@ def test_tool_called_invoke_error(setup_mock_llm) -> None:
     assert agent_response.content == expected_response
 
 
-def test_invalid_tool_name(setup_mock_llm) -> None:
+def test_invalid_tool_name(setup_mock_llm: Callable) -> None:
     llm = setup_mock_llm("non_existent_tool")
     agent = LangGraphAgent(llm, tools=[fake_tool])
     agent_response = agent.invoke(


### PR DESCRIPTION
## Summary
- LangGraphAgentにツール呼び出し機能の土台を実装
- `ToolNode` / `tools_condition` を活用し、LLMがツール呼び出しを要求した際の条件分岐・実行・ループバックのグラフ構造を構築
- `handle_tool_errors=True` により、ツール実行時の例外および不正なツール名のエラーハンドリングを実装

## Test plan
- [x] LLMがツール呼び出しを要求したとき、ツールが実行されて最終回答が返ること
- [x] ツールが例外を吐いたとき、AgentがクラッシュせずLLMに結果が渡ること
- [x] 不正なツール名が要求されたとき、エラーがLLMに渡されて最終回答が返ること
- [x] ツールなしの既存動作が壊れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)