### PR TITLE
feat: 検索ツールをDuckDuckGoからTavilyに置き換え

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "langchain-community>=0.4.1",
     "langchain-core>=1.3.0",
     "langchain-ollama>=1.1.0",
+    "langchain-tavily>=0.2.18",
     "langgraph>=1.1.8",
 ]
 

--- a/src/mnemos/tools/search.py
+++ b/src/mnemos/tools/search.py
@@ -1,5 +1,5 @@
-"""DuckDuckGo検索ツール"""
+"""Tavily検索ツール"""
 
-from langchain_community.tools import DuckDuckGoSearchResults
+from langchain_tavily import TavilySearch
 
-search_tool = DuckDuckGoSearchResults()
+search_tool = TavilySearch(max_results=5, topic="general")

--- a/uv.lock
+++ b/uv.lock
@@ -644,6 +644,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-tavily"
+version = "0.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/6c/b309ef3062b189a82463dc93553804566e71aa393f9ba8954750793c1a6f/langchain_tavily-0.2.18.tar.gz", hash = "sha256:cd7859ae1a6ce79236580ef67072ff5fc43c7ded94e7eac38ff04209ca85a320", size = 25378, upload-time = "2026-04-16T15:23:24.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/9c/0c043e4434b1823f0ac194f66036cbb0569275a99dcb890e0891ecd34fb2/langchain_tavily-0.2.18-py3-none-any.whl", hash = "sha256:dccf3ad1c50e2cb2a89bec11727555805c9df8abd42c1f3ad42ccad86e28aa44", size = 30814, upload-time = "2026-04-16T15:23:23.424Z" },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -843,6 +858,7 @@ dependencies = [
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-ollama" },
+    { name = "langchain-tavily" },
     { name = "langgraph" },
 ]
 
@@ -862,6 +878,7 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.4.1" },
     { name = "langchain-core", specifier = ">=1.3.0" },
     { name = "langchain-ollama", specifier = ">=1.1.0" },
+    { name = "langchain-tavily", specifier = ">=0.2.18" },
     { name = "langgraph", specifier = ">=1.1.8" },
 ]
 


### PR DESCRIPTION
## Summary
- 検索ツールを `DuckDuckGoSearchResults` から `TavilySearch` に置き換え
- DuckDuckGoでは検索結果の品質が低く、LLMエージェントが十分な情報を取得できなかったため、エージェント向けに最適化されたTavilyに移行
- 環境変数 `TAVILY_API_KEY` の設定が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)