### PR TITLE
feat: checkpointerの外部注入とSqliteSaverによる会話履歴永続化

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-ollama>=1.1.0",
     "langchain-tavily>=0.2.18",
     "langgraph>=1.1.8",
+    "langgraph-checkpoint-sqlite>=3.0.3",
 ]
 
 [dependency-groups]

--- a/src/mnemos/adapter/langgraph_agent.py
+++ b/src/mnemos/adapter/langgraph_agent.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Annotated, TypedDict
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph import StateGraph, add_messages
 from langgraph.graph.state import END, START, CompiledStateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
@@ -27,6 +27,7 @@ class LangGraphAgent(Agent):
     def __init__(
         self,
         llm: BaseChatModel,
+        checkpointer: BaseCheckpointSaver,
         tools: list | None = None,
         system_prompt: str | None = None,
     ) -> None:
@@ -34,6 +35,7 @@ class LangGraphAgent(Agent):
         self.llm: Runnable = llm
         self.tools = tools
         self.system_prompt = system_prompt
+        self.checkpointer = checkpointer
         if self.tools is not None:
             self.llm = llm.bind_tools(self.tools)
         self.graph = self._build_graph()
@@ -44,7 +46,7 @@ class LangGraphAgent(Agent):
         self._register_nodes(state_graph)
         self._register_edges(state_graph)
 
-        return state_graph.compile(checkpointer=InMemorySaver())
+        return state_graph.compile(checkpointer=self.checkpointer)
 
     def _register_nodes(self, state_graph: StateGraph) -> None:
         state_graph.add_node("call_llm", self._call_llm)

--- a/tests/integration/test_langgraph_agent_memory.py
+++ b/tests/integration/test_langgraph_agent_memory.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.sqlite import SqliteSaver
 
 from mnemos.adapter.langgraph_agent import LangGraphAgent
 from mnemos.protocols import Message
@@ -7,7 +11,7 @@ from mnemos.protocols import Message
 def test_conversation_history_is_preserved() -> None:
     """同一thread_idで2回invokeしたとき、会話履歴が4件保持されていること。"""
     llm = FakeListChatModel(responses=["応答1", "応答2"])
-    agent = LangGraphAgent(llm)
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver())
     thread_id = "test_thread"
     expected_history_length = 4
 
@@ -16,5 +20,51 @@ def test_conversation_history_is_preserved() -> None:
 
     state = agent.graph.get_state({"configurable": {"thread_id": thread_id}})
     messages = state.values["messages"]
+
+    assert len(messages) == expected_history_length
+
+
+def test_checkpointer_can_be_injected() -> None:
+    """外部からcheckpointerを注入でき、会話履歴が共有される。"""
+    shared_checkpointer = InMemorySaver()
+    thread_id = "test_thread"
+    expected_history_length = 4
+
+    llm1 = FakeListChatModel(responses=["応答1"])
+    agent1 = LangGraphAgent(llm1, checkpointer=shared_checkpointer)
+    agent1.invoke(Message(content="発言1"), thread_id=thread_id)
+
+    llm2 = FakeListChatModel(responses=["応答2"])
+    agent2 = LangGraphAgent(llm2, checkpointer=shared_checkpointer)
+    agent2.invoke(Message(content="発言2"), thread_id=thread_id)
+
+    state = agent2.graph.get_state({"configurable": {"thread_id": thread_id}})
+    messages = state.values["messages"]
+
+    assert len(messages) == expected_history_length
+
+
+def test_conversation_history_persists_with_sqlite(
+    tmp_path: Path,
+) -> None:
+    """SqliteSaverを使うとエージェント再生成後も会話履歴が保持される。"""
+    db_path = str(tmp_path / "test.db")
+    thread_id = "test_thread"
+    expected_history_length = 4
+
+    with SqliteSaver.from_conn_string(db_path) as checkpointer1:
+        llm1 = FakeListChatModel(responses=["応答1"])
+        agent1 = LangGraphAgent(llm1, checkpointer=checkpointer1)
+        agent1.invoke(Message(content="発言1"), thread_id=thread_id)
+
+    with SqliteSaver.from_conn_string(db_path) as checkpointer2:
+        llm2 = FakeListChatModel(responses=["応答2"])
+        agent2 = LangGraphAgent(llm2, checkpointer=checkpointer2)
+        agent2.invoke(Message(content="発言2"), thread_id=thread_id)
+
+        state = agent2.graph.get_state(
+            {"configurable": {"thread_id": thread_id}}
+        )
+        messages = state.values["messages"]
 
     assert len(messages) == expected_history_length

--- a/tests/unit/test_langgraph_agent.py
+++ b/tests/unit/test_langgraph_agent.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import pytest
 from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import InMemorySaver
 
 from mnemos.adapter.langgraph_agent import LangGraphAgent
 from mnemos.protocols import Message
@@ -33,7 +34,7 @@ def setup_tool_use_mock_llm() -> Callable[[str], FakeLLM]:
 def test_ok_response_from_langgraph_agent() -> None:
     expected_response = "こんにちは!"
     llm = FakeLLM(responses=[AIMessage(content=expected_response)])
-    agent = LangGraphAgent(llm)
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver())
     agent_response = agent.invoke(
         Message(content="Hello, Agent!"), thread_id="test_thread"
     )
@@ -43,7 +44,7 @@ def test_ok_response_from_langgraph_agent() -> None:
 def test_tool_called_by_langgraph_agent(setup_tool_use_mock_llm: Callable) -> None:
     expected_response = "こんにちは!"
     llm = setup_tool_use_mock_llm("fake_tool")
-    agent = LangGraphAgent(llm, tools=[fake_tool])
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver(), tools=[fake_tool])
     agent_response = agent.invoke(
         Message(content="Call the tool!"), thread_id="test_thread"
     )
@@ -53,7 +54,7 @@ def test_tool_called_by_langgraph_agent(setup_tool_use_mock_llm: Callable) -> No
 def test_tool_called_invoke_error(setup_tool_use_mock_llm: Callable) -> None:
     expected_response = "こんにちは!"
     llm = setup_tool_use_mock_llm("fake_error_tool")
-    agent = LangGraphAgent(llm, tools=[fake_error_tool])
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver(), tools=[fake_error_tool])
     agent_response = agent.invoke(
         Message(content="Call the tool!"), thread_id="test_thread"
     )
@@ -62,7 +63,7 @@ def test_tool_called_invoke_error(setup_tool_use_mock_llm: Callable) -> None:
 
 def test_invalid_tool_name(setup_tool_use_mock_llm: Callable) -> None:
     llm = setup_tool_use_mock_llm("non_existent_tool")
-    agent = LangGraphAgent(llm, tools=[fake_tool])
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver(), tools=[fake_tool])
     agent_response = agent.invoke(
         Message(content="Call the tool!"), thread_id="test_thread"
     )
@@ -75,7 +76,9 @@ def test_system_prompt_is_passed_to_llm() -> None:
     expected_history_length = 2
 
     llm = FakeLLM(responses=[AIMessage(content="こんにちは!")])
-    agent = LangGraphAgent(llm, system_prompt=system_prompt)
+    agent = LangGraphAgent(
+        llm, checkpointer=InMemorySaver(), system_prompt=system_prompt
+    )
     agent.invoke(Message(content=human_message), thread_id="test_thread")
     llm_recive_content = [history.content for history in llm.histories[-1]]
 
@@ -92,7 +95,9 @@ def test_system_prompt_is_not_duplicated_in_history() -> None:
     expected_history_length = 4
 
     llm = FakeLLM(responses=[AIMessage(content=agent_resopnse_1)])
-    agent = LangGraphAgent(llm, system_prompt=system_prompt)
+    agent = LangGraphAgent(
+        llm, checkpointer=InMemorySaver(), system_prompt=system_prompt
+    )
     agent.invoke(Message(content=human_message_1), thread_id="test_thread")
     agent.invoke(Message(content=human_message_2), thread_id="test_thread")
     llm_recive_content = [history.content for history in llm.histories[-1]]

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -701,6 +710,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/61/40b7f8f29d6de92406e668c35265f409f57064907e31eae84ab3f2a3e3e1/langgraph_checkpoint_sqlite-3.0.3.tar.gz", hash = "sha256:438c234d37dabda979218954c9c6eb1db73bee6492c2f1d3a00552fe23fa34ed", size = 123876, upload-time = "2026-01-19T00:38:44.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/d8/84ef22ee1cc485c4910df450108fd5e246497379522b3c6cfba896f71bf6/langgraph_checkpoint_sqlite-3.0.3-py3-none-any.whl", hash = "sha256:02eb683a79aa6fcda7cd4de43861062a5d160dbbb990ef8a9fd76c979998a952", size = 33593, upload-time = "2026-01-19T00:38:43.288Z" },
+]
+
+[[package]]
 name = "langgraph-prebuilt"
 version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -860,6 +883,7 @@ dependencies = [
     { name = "langchain-ollama" },
     { name = "langchain-tavily" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-sqlite" },
 ]
 
 [package.dev-dependencies]
@@ -880,6 +904,7 @@ requires-dist = [
     { name = "langchain-ollama", specifier = ">=1.1.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18" },
     { name = "langgraph", specifier = ">=1.1.8" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -1601,6 +1626,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
     { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
     { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `LangGraphAgent`の`checkpointer`を必須パラメータに変更し、`InMemorySaver`のハードコードを廃止
- `langgraph-checkpoint-sqlite`を依存に追加し、`SqliteSaver`による会話履歴の永続化を可能に
- checkpointerの注入テスト、SqliteSaverでの再起動後永続化テストを追加

## Test plan
- [x] 既存テスト8件が全てパスすること（checkpointer必須化に伴う修正済み）
- [x] checkpointerの外部注入テストがパスすること
- [x] SqliteSaverでエージェント再生成後も会話履歴が保持されるテストがパスすること
- [x] ruff lint通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)