### PR TITLE
feat: MessagingGateway Protocolの追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "minport>=0.1.3",
     "pyrefly>=0.61.1",
     "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
     "ruff>=0.15.11",
 ]
 

--- a/src/mnemos/protocols/__init__.py
+++ b/src/mnemos/protocols/__init__.py
@@ -2,5 +2,6 @@
 
 from mnemos.protocols.agent import Agent
 from mnemos.protocols.message import Message
+from mnemos.protocols.messaging_gateway import MessagingGateway
 
-__all__ = ["Agent", "Message"]
+__all__ = ["Agent", "Message", "MessagingGateway"]

--- a/src/mnemos/protocols/messaging_gateway.py
+++ b/src/mnemos/protocols/messaging_gateway.py
@@ -1,0 +1,22 @@
+"""外部メッセージングプラットフォームとの橋渡しを行う抽象クラスを定義するモジュール"""
+
+from abc import ABC, abstractmethod
+
+
+class MessagingGateway(ABC):
+    """外部メッセージングプラットフォームとの橋渡しを行う抽象クラス"""
+
+    @abstractmethod
+    async def start(self) -> None:
+        """プラットフォームへの接続を開始し、メッセージの待ち受けを始める"""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """待ち受けを停止してプラットフォームとの接続を切断する"""
+        ...
+
+    @abstractmethod
+    async def handle_message(self, message: str, thread_id: str) -> str:
+        """メッセージを受信して応答を返す"""
+        ...

--- a/tests/fake/__init__.py
+++ b/tests/fake/__init__.py
@@ -1,5 +1,12 @@
 from .fake_agent import FakeAgent
 from .fake_llm import FakeLLM
+from .fake_messaging_gateway import FakeMessagingGateway
 from .fake_tool import fake_error_tool, fake_tool
 
-__all__ = ["FakeAgent", "FakeLLM", "fake_error_tool", "fake_tool"]
+__all__ = [
+    "FakeAgent",
+    "FakeLLM",
+    "FakeMessagingGateway",
+    "fake_error_tool",
+    "fake_tool",
+]

--- a/tests/fake/fake_messaging_gateway.py
+++ b/tests/fake/fake_messaging_gateway.py
@@ -1,0 +1,30 @@
+"""MessagingGatewayのFake実装"""
+
+import asyncio
+
+from mnemos.core.conversation_service import ConversationService
+from mnemos.protocols import MessagingGateway
+
+
+class FakeMessagingGateway(MessagingGateway):
+    """テスト用のMessagingGateway実装"""
+
+    def __init__(self, conversation_service: ConversationService) -> None:
+        self.conversation_service = conversation_service
+        self.is_running = False
+
+    async def start(self) -> None:
+        """ゲートウェイを起動する"""
+        self.is_running = True
+
+    async def stop(self) -> None:
+        """ゲートウェイを停止する"""
+        self.is_running = False
+
+    async def handle_message(self, message: str, thread_id: str) -> str:
+        """メッセージを受信して応答を返す"""
+        return await asyncio.to_thread(
+            self.conversation_service.handle_message,
+            message,
+            thread_id,
+        )

--- a/tests/integration/test_messaging_gateway.py
+++ b/tests/integration/test_messaging_gateway.py
@@ -1,0 +1,27 @@
+"""MessagingGatewayの結合テスト"""
+
+import pytest
+
+from mnemos.core.conversation_service import ConversationService
+from tests.fake import FakeAgent, FakeMessagingGateway
+
+
+@pytest.mark.asyncio
+async def test_handle_message_returns_agent_response() -> None:
+    """メッセージを受け取り、Agentからの応答を返す"""
+    expected = "こんにちは、何かお手伝いできることはありますか。"
+    agent = FakeAgent(response=expected)
+    service = ConversationService(agent)
+    gateway = FakeMessagingGateway(conversation_service=service)
+    response = await gateway.handle_message("こんにちは", "test_thread")
+    assert response == expected
+
+
+@pytest.mark.asyncio
+async def test_handle_message_passes_correct_thread_id() -> None:
+    """thread_idがAgentまで正しく伝播される"""
+    agent = FakeAgent(response="ok")
+    service = ConversationService(agent)
+    gateway = FakeMessagingGateway(conversation_service=service)
+    await gateway.handle_message("テスト", "thread_123")
+    assert agent.received_thread_id == "thread_123"

--- a/tests/unit/test_messaging_gateway.py
+++ b/tests/unit/test_messaging_gateway.py
@@ -1,0 +1,36 @@
+"""MessagingGatewayのユニットテスト"""
+
+import pytest
+
+from mnemos.core.conversation_service import ConversationService
+from tests.fake import FakeAgent, FakeMessagingGateway
+
+
+@pytest.mark.asyncio
+async def test_gateway_is_not_running_by_default() -> None:
+    """初期状態ではゲートウェイは起動していない"""
+    agent = FakeAgent(response="ok")
+    service = ConversationService(agent)
+    gateway = FakeMessagingGateway(conversation_service=service)
+    assert not gateway.is_running
+
+
+@pytest.mark.asyncio
+async def test_start_sets_running() -> None:
+    """startを呼ぶとゲートウェイが起動状態になる"""
+    agent = FakeAgent(response="ok")
+    service = ConversationService(agent)
+    gateway = FakeMessagingGateway(conversation_service=service)
+    await gateway.start()
+    assert gateway.is_running
+
+
+@pytest.mark.asyncio
+async def test_stop_sets_not_running() -> None:
+    """stopを呼ぶとゲートウェイが停止状態になる"""
+    agent = FakeAgent(response="ok")
+    service = ConversationService(agent)
+    gateway = FakeMessagingGateway(conversation_service=service)
+    await gateway.start()
+    await gateway.stop()
+    assert not gateway.is_running

--- a/uv.lock
+++ b/uv.lock
@@ -891,6 +891,7 @@ dev = [
     { name = "minport" },
     { name = "pyrefly" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -912,6 +913,7 @@ dev = [
     { name = "minport", specifier = ">=0.1.3" },
     { name = "pyrefly", specifier = ">=0.61.1" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.11" },
 ]
 
@@ -1473,6 +1475,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- 外部メッセージングプラットフォーム（Telegram等）との橋渡しを行う`MessagingGateway`抽象クラスを追加
- `start` / `stop` / `handle_message` の3つのasyncメソッドをインターフェースとして定義
- テスト用の`FakeMessagingGateway`実装およびunit/integrationテストを追加

## Test plan
- [x] `MessagingGateway`のライフサイクル（start/stop）のunitテスト
- [x] `ConversationService`経由でのメッセージ伝播のintegrationテスト
- [x] 既存テスト16件が全てパスすることを確認
- [x] ruff lintパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)