### PR TITLE
feat: TelegramGatewayの実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "langchain-tavily>=0.2.18",
     "langgraph>=1.1.8",
     "langgraph-checkpoint-sqlite>=3.0.3",
+    "python-telegram-bot>=22.7",
 ]
 
 [dependency-groups]

--- a/src/mnemos/adapter/gateway/__init__.py
+++ b/src/mnemos/adapter/gateway/__init__.py
@@ -1,0 +1,5 @@
+"""外部メッセージングプラットフォームとの橋渡しを行うアダプター"""
+
+from mnemos.adapter.gateway.telegram import TelegramGateway
+
+__all__ = ["TelegramGateway"]

--- a/src/mnemos/adapter/gateway/telegram.py
+++ b/src/mnemos/adapter/gateway/telegram.py
@@ -1,0 +1,68 @@
+"""Telegramを用いたMessagingGatewayの具体実装"""
+
+import asyncio
+import logging
+
+from telegram import Update
+from telegram.ext import (
+    Application,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from mnemos.core.conversation_service import ConversationService
+from mnemos.protocols import MessagingGateway
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramGateway(MessagingGateway):
+    """Telegram Botを用いたMessagingGatewayの具体実装"""
+
+    def __init__(
+        self,
+        bot_token: str,
+        conversation_service: ConversationService,
+    ) -> None:
+        """TelegramGatewayのコンストラクタ"""
+        self.conversation_service = conversation_service
+        self.app = Application.builder().token(bot_token).build()
+        self.app.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_message)
+        )
+
+    async def start(self) -> None:
+        """Telegram Botのポーリングを開始する"""
+        await self.app.initialize()
+        await self.app.start()
+        await self.app.updater.start_polling()
+        logger.info("Telegram Bot started")
+
+    async def stop(self) -> None:
+        """Telegram Botのポーリングを停止する"""
+        await self.app.updater.stop()
+        await self.app.stop()
+        await self.app.shutdown()
+        logger.info("Telegram Bot stopped")
+
+    async def handle_message(self, message: str, thread_id: str) -> str:
+        """メッセージを受信して応答を返す"""
+        return await asyncio.to_thread(
+            self.conversation_service.handle_message,
+            message,
+            thread_id,
+        )
+
+    async def _on_message(
+        self,
+        update: Update,
+        _context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Telegramからメッセージを受信したときのコールバック"""
+        if update.message is None or update.message.text is None:
+            return
+
+        thread_id = str(update.message.chat_id)
+        response = await self.handle_message(update.message.text, thread_id)
+        await update.message.reply_text(response)

--- a/src/mnemos/adapter/gateway/telegram.py
+++ b/src/mnemos/adapter/gateway/telegram.py
@@ -8,6 +8,7 @@ from telegram.ext import (
     Application,
     ContextTypes,
     MessageHandler,
+    Updater,
     filters,
 )
 
@@ -36,15 +37,22 @@ class TelegramGateway(MessagingGateway):
         """Telegram Botのポーリングを開始する"""
         await self.app.initialize()
         await self.app.start()
-        await self.app.updater.start_polling()
+        await self._get_updater().start_polling()
         logger.info("Telegram Bot started")
 
     async def stop(self) -> None:
         """Telegram Botのポーリングを停止する"""
-        await self.app.updater.stop()
+        await self._get_updater().stop()
         await self.app.stop()
         await self.app.shutdown()
         logger.info("Telegram Bot stopped")
+
+    def _get_updater(self) -> Updater:
+        """Updaterを取得する。存在しない場合はRuntimeErrorを送出する。"""
+        if self.app.updater is None:
+            msg = "Updater is not available"
+            raise RuntimeError(msg)
+        return self.app.updater
 
     async def handle_message(self, message: str, thread_id: str) -> str:
         """メッセージを受信して応答を返す"""

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
 
@@ -884,6 +885,7 @@ dependencies = [
     { name = "langchain-tavily" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "python-telegram-bot" },
 ]
 
 [package.dev-dependencies]
@@ -906,6 +908,7 @@ requires-dist = [
     { name = "langchain-tavily", specifier = ">=0.2.18" },
     { name = "langgraph", specifier = ">=1.1.8" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.3" },
+    { name = "python-telegram-bot", specifier = ">=22.7" },
 ]
 
 [package.metadata.requires-dev]
@@ -1497,6 +1500,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore", marker = "python_full_version >= '3.14'" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- MessagingGateway Protocolを実装する`TelegramGateway`をadapter層に追加
- `adapter/gateway/`ディレクトリを新設し、将来のCLI Gateway等と共存可能な構成とした
- python-telegram-botを依存に追加

## 使い方
```bash
TELEGRAM_BOT_TOKEN=your-token uv run python main.py telegram
```

## Test plan
- [x] Telegram Botにメッセージを送り、Agentからの応答が返ることをe2eで確認
- [x] 既存テスト16件が全てパスすることを確認
- [x] ruff lintパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)