### PR TITLE
feat: Agentにストリーミングイベントのサポートを追加

### DIFF
--- a/src/mnemos/adapter/langgraph_agent.py
+++ b/src/mnemos/adapter/langgraph_agent.py
@@ -1,6 +1,7 @@
 """Langgraphを用いたエージェントの具体実装"""
 
-from typing import TYPE_CHECKING, Annotated, TypedDict
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Annotated, Any, TypedDict
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -9,7 +10,7 @@ from langgraph.graph import StateGraph, add_messages
 from langgraph.graph.state import END, START, CompiledStateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
 
-from mnemos.protocols import Agent, Message
+from mnemos.protocols import Agent, AgentEvent, Message
 
 if TYPE_CHECKING:
     from langchain_core.runnables import Runnable
@@ -80,3 +81,26 @@ class LangGraphAgent(Agent):
         )
         last_message = response["messages"][-1]
         return Message(content=last_message.content)
+
+    def stream(self, message: Message, thread_id: str) -> Generator[AgentEvent]:
+        """メッセージを受け取り、処理中のイベントをストリーミングで返す関数"""
+        config = {"configurable": {"thread_id": thread_id}}
+        for chunk in self.graph.stream(
+            {"messages": [HumanMessage(content=message.content)]},
+            config=config,
+            stream_mode="updates",
+        ):
+            yield from self._chunk_to_events(chunk)
+
+    def _chunk_to_events(self, chunk: dict[str, Any]) -> Generator[AgentEvent]:
+        """LangGraphのストリームチャンクをAgentEventに変換する"""
+        if "call_llm" in chunk:
+            ai_message: AIMessage = chunk["call_llm"]["messages"][0]
+            if ai_message.tool_calls:
+                for tool_call in ai_message.tool_calls:
+                    yield AgentEvent(
+                        type="tool_call_start",
+                        data=f"{tool_call['name']}: {tool_call['args']}",
+                    )
+            elif ai_message.content:
+                yield AgentEvent(type="response", data=ai_message.content)

--- a/src/mnemos/adapter/langgraph_agent.py
+++ b/src/mnemos/adapter/langgraph_agent.py
@@ -103,4 +103,4 @@ class LangGraphAgent(Agent):
                         data=f"{tool_call['name']}: {tool_call['args']}",
                     )
             elif ai_message.content:
-                yield AgentEvent(type="response", data=ai_message.content)
+                yield AgentEvent(type="response", data=str(ai_message.content))

--- a/src/mnemos/protocols/__init__.py
+++ b/src/mnemos/protocols/__init__.py
@@ -1,7 +1,8 @@
 """各種LLM・ツールなどに対するインターフェースを定義するレイヤー"""
 
 from mnemos.protocols.agent import Agent
+from mnemos.protocols.event import AgentEvent
 from mnemos.protocols.message import Message
 from mnemos.protocols.messaging_gateway import MessagingGateway
 
-__all__ = ["Agent", "Message", "MessagingGateway"]
+__all__ = ["Agent", "AgentEvent", "Message", "MessagingGateway"]

--- a/src/mnemos/protocols/agent.py
+++ b/src/mnemos/protocols/agent.py
@@ -1,7 +1,9 @@
 """エージェントの抽象クラスを定義するモジュール"""
 
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 
+from mnemos.protocols.event import AgentEvent
 from mnemos.protocols.message import Message
 
 
@@ -11,4 +13,9 @@ class Agent(ABC):
     @abstractmethod
     def invoke(self, message: Message, thread_id: str) -> Message:
         """エージェントを呼び出す関数"""
+        ...
+
+    @abstractmethod
+    def stream(self, message: Message, thread_id: str) -> Generator[AgentEvent]:
+        """エージェントをストリーミングモードで呼び出す関数"""
         ...

--- a/src/mnemos/protocols/event.py
+++ b/src/mnemos/protocols/event.py
@@ -1,0 +1,11 @@
+"""エージェントのストリーミングイベントを定義するモジュール"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentEvent:
+    """エージェントの処理中に発生するイベント"""
+
+    type: str
+    data: str = ""

--- a/tests/fake/fake_agent.py
+++ b/tests/fake/fake_agent.py
@@ -1,4 +1,6 @@
-from mnemos.protocols import Agent, Message
+from collections.abc import Generator
+
+from mnemos.protocols import Agent, AgentEvent, Message
 
 
 class FakeAgent(Agent):
@@ -11,3 +13,8 @@ class FakeAgent(Agent):
         self.received_message = message
         self.received_thread_id = thread_id
         return Message(content=self.response)
+
+    def stream(self, message: Message, thread_id: str) -> Generator[AgentEvent]:
+        self.received_message = message
+        self.received_thread_id = thread_id
+        yield AgentEvent(type="response", data=self.response)

--- a/tests/unit/test_langgraph_agent.py
+++ b/tests/unit/test_langgraph_agent.py
@@ -87,6 +87,22 @@ def test_system_prompt_is_passed_to_llm() -> None:
     assert len(llm_recive_content) == expected_history_length
 
 
+def test_stream_yields_tool_call_and_response(
+    setup_tool_use_mock_llm: Callable,
+) -> None:
+    llm = setup_tool_use_mock_llm("fake_tool")
+    agent = LangGraphAgent(llm, checkpointer=InMemorySaver(), tools=[fake_tool])
+    events = list(
+        agent.stream(Message(content="Call the tool!"), thread_id="test_thread")
+    )
+
+    assert len(events) == 2  # noqa: PLR2004
+    assert events[0].type == "tool_call_start"
+    assert "fake_tool" in events[0].data
+    assert events[1].type == "response"
+    assert events[1].data == "こんにちは!"
+
+
 def test_system_prompt_is_not_duplicated_in_history() -> None:
     system_prompt = "これはシステムプロンプトです。"
     human_message_1 = "Hello, Agent!"


### PR DESCRIPTION
## Summary
- `AgentEvent`プロトコルを追加し、エージェント処理中のイベント（ツール呼び出し、最終応答）を表現できるようにした
- `Agent`抽象クラスに`stream()`メソッドを追加し、イベントをGeneratorで逐次返すインターフェースを定義した
- `LangGraphAgent`にLangGraphの`stream(mode=updates)`を利用した具体実装を追加した

## Test plan
- [x] `test_stream_yields_tool_call_and_response` — ツール呼び出しイベントと最終応答イベントが正しい順序・内容でyieldされることを検証
- [x] 既存テスト17件が全てパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)